### PR TITLE
Add Inventory Item metadata to Dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,26 +27,29 @@ To install ckanext-inventory:
 
 1. Activate your CKAN virtual environment, for example::
 
-     . /usr/lib/ckan/default/bin/activate
+```
+. /usr/lib/ckan/default/bin/activate
+```
 
-2. Install the ckanext-inventory Python package into your virtual environment::
+2. Install the ckanext-inventory Python package into your virtual environment:
 
-     pip install ckanext-inventory
+```
+pip install ckanext-inventory
+```
 
-3. Add ``inventory`` to the ``ckan.plugins`` setting in your CKAN
-   config file (by default the config file is located at
-   ``/etc/ckan/default/production.ini``).
+3. Add `inventory inventoryfix` to the `ckan.plugins` setting in your CKAN
+   config file.
 
-4. Restart CKAN. For example if you've deployed CKAN with Apache on Ubuntu::
-
-     sudo service apache2 reload
+4. Restart CKAN.
 
 ## Development Installation
 
 To install ckanext-inventory for development, activate your CKAN virtualenv and
-do::
+do:
 
-    git clone https://github.com/govro/ckanext-inventory.git
-    cd ckanext-inventory
-    python setup.py develop
-    pip install -r dev-requirements.txt
+```
+git clone https://github.com/govro/ckanext-inventory.git
+cd ckanext-inventory
+python setup.py develop
+pip install -r dev-requirements.txt
+```

--- a/ckanext/inventory/logic/validators.py
+++ b/ckanext/inventory/logic/validators.py
@@ -6,6 +6,9 @@ def update_package_inventory_entry(value, context):
     model = context['model']
     session = context['session']
 
+    if not value:
+        raise Invalid(_('No inventory entry provided'))
+
     result = session.query(InventoryEntry).filter_by(id=value).first()
 
     if not result:

--- a/ckanext/inventory/logic/validators.py
+++ b/ckanext/inventory/logic/validators.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from ckanext.inventory.model import InventoryEntry
+from ckan.plugins.toolkit import Invalid, _
+
+def update_package_inventory_entry(value, context):
+    model = context['model']
+    session = context['session']
+
+    result = session.query(InventoryEntry).filter_by(id=value).first()
+
+    if not result:
+        raise Invalid(_('Not found') + ': %s' % value)
+
+    # TODO @palcu: use a hook from IPackageController
+    result.last_added_dataset_timestamp = datetime.now()
+    result.save()
+
+    return value

--- a/ckanext/inventory/plugin.py
+++ b/ckanext/inventory/plugin.py
@@ -5,7 +5,8 @@ from ckan.plugins import (
     IConfigurable, IDatasetForm, IValidators)
 from ckan.plugins.toolkit import (
     add_template_directory, add_public_directory, add_resource,
-    DefaultOrganizationForm, get_validator, get_converter, DefaultDatasetForm)
+    DefaultOrganizationForm, get_validator, get_converter, DefaultDatasetForm,
+    get_action, c)
 from ckanext.inventory.logic.action import (
     pending_user_list, activate_user, organization_by_inventory_id)
 from ckanext.inventory.logic.action.inventory_entry import (
@@ -141,6 +142,20 @@ class InventoryPluginFix(SingletonPlugin, DefaultDatasetForm):
                                    get_validator('ignore_missing')]
         })
         return schema
+
+    def setup_template_variables(self, context, data_dict):
+        """Add inventory entries that the user has access to."""
+        # TODO @palcu: send this to it's own logic method
+        organizations = get_action('organization_list_for_user')\
+            (context, {'permission': 'create_dataset'})
+
+        inventory_entries = []
+        for organization in organizations:
+            inventory_entries += get_action('inventory_entry_list')(context, {'name': organization['id']})
+        c.inventory_entries = [(x['id'], x['title']) for x in inventory_entries]
+
+        super(InventoryPluginFix, self).setup_template_variables(context,
+                                                                 data_dict)
 
     def package_types(self):
         return ['dataset']

--- a/ckanext/inventory/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/inventory/templates/package/snippets/package_basic_fields.html
@@ -1,5 +1,17 @@
 {% ckan_extends %}
 
 {% block package_basic_fields_custom %}
-  {{ form.input('inventory_entry_id', label=_('Inventory Entry'), id='field-inventory_entry_id', placeholder=_('Just ID for now'), value=data.inventory_entry_id, error=errors.inventory_entry_id, classes=['control-medium']) }}
+<div class="control-group">
+  {% set error = errors.inventory_entry_id %}
+  <label class="control-label" for="field-inventory_entry_id">{{ _("Inventory Entry") }}</label>
+  <div class="controls">
+    <select id="field-inventory_entry_id" name="inventory_entry_id" data-module="autocomplete">
+      {% set existing_inventory_entry_id = data.get('inventory_entry_id') %}
+      {% for inventory_entry_id, inventory_entry_title in c.inventory_entries %}
+        <option value="{{ inventory_entry_id }}" {% if existing_inventory_entry_id == inventory_entry_id %}selected="selected"{% endif %}>{{ inventory_entry_title }}</option>
+      {% endfor %}
+    </select>
+    {% if error %}<span class="error-block">{{ error }}</span>{% endif %}
+  </div>
+</div>
 {% endblock %}

--- a/ckanext/inventory/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/inventory/templates/package/snippets/package_basic_fields.html
@@ -1,0 +1,5 @@
+{% ckan_extends %}
+
+{% block package_basic_fields_custom %}
+  {{ form.input('inventory_entry_id', label=_('Inventory Entry'), id='field-inventory_entry_id', placeholder=_('Just ID for now'), value=data.inventory_entry_id, error=errors.inventory_entry_id, classes=['control-medium']) }}
+{% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -78,5 +78,6 @@ setup(
     entry_points='''
         [ckan.plugins]
         inventory=ckanext.inventory.plugin:InventoryPlugin
+        inventoryfix=ckanext.inventory.plugin:InventoryPluginFix
     ''',
 )

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,14 @@ setup(
     # http://packaging.python.org/en/latest/tutorial.html#version
     version='0.0.1',
 
-    description='''CKAN Extension for receiving dataset inventories from organizations and tracking''',
+    description='''CKAN Extension for receiving and tracking dataset inventories from organizations''',
     long_description=long_description,
 
     # The project's main homepage.
     url='https://github.com/govro/ckanext-inventory',
 
     # Author details
-    author='''their status.Alex Palcuie''',
+    author='''Alex Palcuie''',
     author_email='''alex.palcuie@gmail.com''',
 
     # Choose your license


### PR DESCRIPTION
# Need

```
As an inventory management manager
I need to add datasets that are linked to an inventory item
```
# Deliverables
- dropdown with inventory items when I add an inventory using [`IDatasetForm`](http://docs.ckan.org/en/latest/extensions/adding-custom-fields.html)
- signal that updates the `last_updated` field in an inventory item
## Notes
- base model is `package.py`
- this field should be required on save for every existing and future dataset
## Questions
- is updating a dataset considered updating `last_update`?

No, just the adding date of the dataset. Till we get to the DCAT standard.
